### PR TITLE
Allow no object to be passed in with createPullstateCore

### DIFF
--- a/src/PullstateCore.tsx
+++ b/src/PullstateCore.tsx
@@ -201,7 +201,7 @@ class PullstateInstance<T extends IPullstateAllStores = IPullstateAllStores>
   }
 }
 
-export function createPullstateCore<T extends IPullstateAllStores = IPullstateAllStores>(allStores: T) {
+export function createPullstateCore<T extends IPullstateAllStores = IPullstateAllStores>(allStores: T = {}) {
   return new PullstateSingleton<T>(allStores);
 }
 

--- a/src/PullstateCore.tsx
+++ b/src/PullstateCore.tsx
@@ -201,7 +201,7 @@ class PullstateInstance<T extends IPullstateAllStores = IPullstateAllStores>
   }
 }
 
-export function createPullstateCore<T extends IPullstateAllStores = IPullstateAllStores>(allStores: T = {}) {
+export function createPullstateCore<T extends IPullstateAllStores = IPullstateAllStores>(allStores: T = {} as T) {
   return new PullstateSingleton<T>(allStores);
 }
 

--- a/test/tests/core.tests.tsx
+++ b/test/tests/core.tests.tsx
@@ -1,0 +1,12 @@
+import { createPullstateCore } from "../../src/index";
+import { TestUIStore } from "./testStores/TestUIStore";
+
+describe("createPullstateCore", () => {
+  it("Should be able to be created without any stores", () => {
+    expect(createPullstateCore()).toBeTruthy();
+  });
+
+  it("Should be able to be created with a store", () => {
+    expect(createPullstateCore({ TestUIStore })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Currently, you have to pass in something into `createPullstateCore` in order for the types to be fulfilled. I am using pullstate without any stores, just actions, and so I must do:

`createPullstateCore({})`

to satisfy the types. Now I do not need to pass in an object.

Happy to remove the test, I just wanted to know it was working :)