### PR TITLE
useStoreState gets no more updates after hot reload

### DIFF
--- a/src/useStoreState.ts
+++ b/src/useStoreState.ts
@@ -38,7 +38,7 @@ function useStoreState(
 
     store._addUpdateListener(onStoreUpdate);
     return () => store._removeUpdateListener(onStoreUpdate);
-  }, [store, ...deps]);
+  }, deps);
 
   return subState;
 }


### PR DESCRIPTION
Hi pullstate!
I **love** the approach. Especially in comparison to Redux this is so much more elegant and lean. I was thinking of something similar when I stumbled upon this project. 😉

I noticed that `useStoreState` stops to update as soon as my app hot reloads however. So I was calling update again and again, but my component was not re-rendering anymore.

After looking at the source, I am not sure what exactly is causing the problem, but I suspect it is hidden in the slightly confusing way `useStoreState` uses refs to manage its listener.
I was able to change it to use only `useState` and `useEffect` and now it works nicely for me. It's also simpler, shorter by half and more React best practice. (I believe `useRef` should be a last resort, because it usually make things difficult to understand and therefore more error prone.)

Anyway, if you are interested, consider this PR. I'd be happy to discuss the changes or any concerns that you might have.

