### PR TITLE
Switched on strict and fixed resulting errors.

### DIFF
--- a/src/PullstateCore.tsx
+++ b/src/PullstateCore.tsx
@@ -30,7 +30,7 @@ export const PullstateProvider = <T extends IPullstateAllStores = IPullstateAllS
   return <PullstateContext.Provider value={instance}>{children}</PullstateContext.Provider>;
 };
 
-let singleton: PullstateSingleton | null = null;
+let singleton: PullstateSingleton<any> | null = null;
 
 export const clientStores: {
   internalClientStores: true;
@@ -43,7 +43,7 @@ export const clientStores: {
 };
 
 export type TMultiStoreAction<
-  P extends PullstateSingleton,
+  P extends PullstateSingleton<S>,
   S extends IPullstateAllStores = P extends PullstateSingleton<infer ST> ? ST : any
 > = (update: TMultiStoreUpdateMap<S>) => void;
 
@@ -127,7 +127,9 @@ export class PullstateSingleton<S extends IPullstateAllStores = IPullstateAllSto
       };
     }
 
-    const action: (update: TMultiStoreAction<PullstateSingleton<S>, S>) => TMultiStoreAction<PullstateSingleton<S>, S> = action => action;
+    const action: (
+      update: TMultiStoreAction<PullstateSingleton<S>, S>
+    ) => TMultiStoreAction<PullstateSingleton<S>, S> = action => action;
     const act = (action: TMultiStoreAction<PullstateSingleton<S>, S>): void => {
       updatedStores.clear();
       action(actUpdateMap);
@@ -153,7 +155,7 @@ export class PullstateSingleton<S extends IPullstateAllStores = IPullstateAllSto
 }
 
 type TMultiStoreUpdateMap<S extends IPullstateAllStores> = {
-  [K in keyof S]: (updater: TUpdateFunction<S[K] extends Store<infer T> ? T : any>) => void
+  [K in keyof S]: (updater: TUpdateFunction<S[K] extends Store<infer T> ? T : any>) => void;
 };
 
 interface IPullstateSnapshot {
@@ -207,7 +209,7 @@ class PullstateInstance<T extends IPullstateAllStores = IPullstateAllStores>
   }
 
   getPullstateSnapshot(): IPullstateSnapshot {
-    const allState = {};
+    const allState = {} as IPullstateSnapshot["allState"];
 
     for (const storeName of Object.keys(this._stores)) {
       allState[storeName] = this._stores[storeName].getRawState();

--- a/src/async.ts
+++ b/src/async.ts
@@ -129,12 +129,10 @@ export function errorResult<R = any, T extends string = string>(
 }
 
 export class PullstateAsyncError extends Error {
-  message: string;
   tags: string[];
 
   constructor(message: string, tags: string[]) {
     super(message);
-    this.message = message;
     this.tags = tags;
   }
 }

--- a/src/async.ts
+++ b/src/async.ts
@@ -46,7 +46,7 @@ export const clientAsyncCache: IPullstateAsyncCache = {
 
 let asyncCreationOrdinal = 0;
 
-export function keyFromObject(json) {
+export function keyFromObject(json: any) {
   if (json === null) {
     return "(n)";
   }
@@ -134,11 +134,12 @@ export class PullstateAsyncError extends Error {
 
   constructor(message: string, tags: string[]) {
     super(message);
+    this.message = message;
     this.tags = tags;
   }
 }
 
-let storeErrorProxy;
+let storeErrorProxy: any;
 try {
   storeErrorProxy = new Proxy(
     {},
@@ -802,10 +803,10 @@ further looping. Fix in your cacheBreakHook() is needed.`);
     const cache: IPullstateAsyncCache = onServer ? useContext(PullstateContext)!._asyncCache : clientAsyncCache;
 
     if (cache.results.hasOwnProperty(key) && !cache.results[key][2].error) {
-      const currentCached: any = cache.results[key][2].payload;
+      const currentCached: R = cache.results[key][2].payload;
 
       const newResult = {
-        payload: (produce(currentCached, s => updater(s, currentCached)) as unknown) as R,
+        payload: (produce(currentCached, (s: R) => updater(s, currentCached)) as unknown) as R,
         error: false,
         message: cache.results[key][2].message,
         tags: cache.results[key][2].tags,
@@ -890,7 +891,7 @@ further looping. Fix in your cacheBreakHook() is needed.`);
     }
   };
 
-  let delayedRunActionTimeout;
+  let delayedRunActionTimeout: NodeJS.Timeout;
 
   const delayedRun: TAsyncActionDelayedRun<A> = (
     args = {} as A,
@@ -923,7 +924,7 @@ further looping. Fix in your cacheBreakHook() is needed.`);
   };
 
   const use: TAsyncActionUse<A, R, T> = (
-    args: A,
+    args?: A,
     {
       initiate = true,
       ssr = true,

--- a/src/fastDeepEqual.d.ts
+++ b/src/fastDeepEqual.d.ts
@@ -1,0 +1,4 @@
+declare module "fast-deep-equal/es6" {
+  const equal: (a: any, b: any) => boolean;
+  export = equal;
+}

--- a/src/useStoreState.ts
+++ b/src/useStoreState.ts
@@ -9,7 +9,7 @@ import { Store } from "./Store";
 export interface IUpdateRef {
   shouldUpdate: boolean;
   onStoreUpdate: (() => void) | null;
-  getSubState?: (state) => any;
+  getSubState?: (state: any) => any;
   currentSubState: any;
   setInitial: boolean;
 }
@@ -20,7 +20,7 @@ function useStoreState<S = any, SS = any>(
   getSubState: (state: S) => SS,
   deps?: ReadonlyArray<any>
 ): SS;
-function useStoreState(store: Store, getSubState?: (state) => any, deps?: ReadonlyArray<any>): any {
+function useStoreState(store: Store, getSubState?: (state: any) => any, deps?: ReadonlyArray<any>): any {
   const updateRef = useRef<IUpdateRef>({
     shouldUpdate: true,
     onStoreUpdate: null,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "inlineSourceMap": false,
     "declaration": true,
     "removeComments": true,
-    "strictNullChecks": true
+    "strict": true
   },
   "exclude": [
     "./test"


### PR DESCRIPTION
Hi again! When I try to type check my project I see the following errors. I could pin it down to me using typescript's `compilerOptions.strict: true` setting. I can easily work around this by setting `compilerOptions.skipLibCheck: true`, but since those errors might always point to potential bugs in libs, it would of be nicer to keep this off.

Maybe you want to consider using the strict flag as well. I tried it quickly and with a few changes here and there - mostly getting rid of implicit any - it seems to be fine. The only non-ideal aspect is that the types for `fast-deep-equal/es6` are broken, which results in an error with strict, so I needed to add a .d.ts file to override it. This problem should disappear once https://github.com/epoberezkin/fast-deep-equal/pull/48 is merged.

What do you think? If you are interested, I'd be happy to flesh things out where you still might have concerns. Or if you prefer to not use strict, I can also create a PR to only fix the missing types that lead to the error. Let me know. 😉

```
node_modules/pullstate/dist/PullstateCore.d.ts:27:44 - error TS2344: Type 'PullstateSingleton<S>' does not satisfy the constraint 'PullstateSingleton<IPullstateAllStores>'.
  The types returned by 'actionSetup().action(...)' are incompatible between these types.
    Type 'TMultiStoreAction<PullstateSingleton<S>, S>' is not assignable to type 'TMultiStoreAction<PullstateSingleton<IPullstateAllStores>, IPullstateAllStores>'.
      Types of parameters 'update' and 'update' are incompatible.
        Type 'TMultiStoreUpdateMap<IPullstateAllStores>' is not assignable to type 'TMultiStoreUpdateMap<S>'.

27         action: (update: TMultiStoreAction<PullstateSingleton<S>, S>) => TMultiStoreAction<PullstateSingleton<S>, S>;
                                              ~~~~~~~~~~~~~~~~~~~~~

node_modules/pullstate/dist/PullstateCore.d.ts:27:92 - error TS2344: Type 'PullstateSingleton<S>' does not satisfy the constraint 'PullstateSingleton<IPullstateAllStores>'.

27         action: (update: TMultiStoreAction<PullstateSingleton<S>, S>) => TMultiStoreAction<PullstateSingleton<S>, S>;
                                                                                              ~~~~~~~~~~~~~~~~~~~~~

node_modules/pullstate/dist/PullstateCore.d.ts:28:41 - error TS2344: Type 'PullstateSingleton<S>' does not satisfy the constraint 'PullstateSingleton<IPullstateAllStores>'.

28         act: (action: TMultiStoreAction<PullstateSingleton<S>, S>) => void;
                                           ~~~~~~~~~~~~~~~~~~~~~
```
