### PR TITLE
Fix for useWatch and useBeckon after hot reload

### DIFF
--- a/src/async.ts
+++ b/src/async.ts
@@ -618,27 +618,26 @@ further looping. Fix in your cacheBreakHook() is needed.`);
         }*/
       };
 
-      useMemo(() => {
+      useEffect(() => {
         if (!dormant) {
           if (!cache.listeners.hasOwnProperty(key)) {
             cache.listeners[key] = {};
           }
           cache.listeners[key][watchId.current] = onAsyncStateChanged;
+          shouldUpdate[key][watchId.current] = true;
+
           // console.log(`[${key}][${watchId}] Added listener (total now: ${Object.keys(cache.listeners[key]).length})`);
         }
-      }, [key]);
 
-      useEffect(
-        () => () => {
+        return () => {
           if (!dormant) {
             // console.log(`[${key}][${watchId}] Removing listener (before: ${Object.keys(cache.listeners[key]).length})`);
             delete cache.listeners[key][watchId.current];
             shouldUpdate[key][watchId.current] = false;
             // console.log(`[${key}][${watchId}] Removed listener (after: ${Object.keys(cache.listeners[key]).length})`);
           }
-        },
-        [key]
-      );
+        };
+      }, [key]);
     }
 
     // Purely for forcing this hook to update

--- a/src/async.ts
+++ b/src/async.ts
@@ -618,11 +618,16 @@ further looping. Fix in your cacheBreakHook() is needed.`);
         }*/
       };
 
+      if (!dormant) {
+        if (!cache.listeners.hasOwnProperty(key)) {
+          cache.listeners[key] = {};
+        }
+        cache.listeners[key][watchId.current] = onAsyncStateChanged;
+        // console.log(`[${key}][${watchId}] Added listener (total now: ${Object.keys(cache.listeners[key]).length})`);
+      }
+
       useEffect(() => {
         if (!dormant) {
-          if (!cache.listeners.hasOwnProperty(key)) {
-            cache.listeners[key] = {};
-          }
           cache.listeners[key][watchId.current] = onAsyncStateChanged;
           shouldUpdate[key][watchId.current] = true;
 


### PR DESCRIPTION
I found another issue with hot reloading or more generally said: remounting. Quite similar to #28 

A component using `useBeckon` did not receive updates anymore after hot reload took place. The same should be true for `useWatch` since that's used by `useBeckon` under the hood.

What happened:
1. `useBeckon` is executed, `shouldUpdate` is set directly, the listener is attached in `useMemo`
2. hot reload occurs => component is unmounted and remounted
3. `useBeckon` is executed, including `useMemo`
4. `useEffect` teardown triggers after that, resets `shouldUpdate` and removes listener.
5. No updates anymore...

My solution proposal:
- Move the logic out of `useMemo` (nothing expensive happens, right? Just two assignments)
- Attched listener and set `shouldUpdate` in `useEffect` as well.

What do you think?