### PR TITLE
Remove peer dependency on immer

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "webpack-cli": "^3.3.12"
   },
   "peerDependencies": {
-    "immer": "^8.0.1",
     "react": "^16.12.0"
   }
 }


### PR DESCRIPTION
immer is already a direct dependency, so there's no reason to have it as a peer dependency.