### PR TITLE
Changing build target to es2016

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "jsx": "react",
     "module": "esnext",
     "esModuleInterop": true,
-    "target": "ES2019",
+    "target": "ES2016",
     "sourceMap": true,
     "inlineSourceMap": false,
     "sourceRoot": "src",


### PR DESCRIPTION
Hi,
This is in reference to issue #96 . Current browsers have shaky support for targets beyond 2016.
Also, thanks for the plugin, I am already using it in production. 